### PR TITLE
Update Atlantis version to V0.4.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM runatlantis/atlantis:v0.4.1
+FROM runatlantis/atlantis:v0.4.13
 
 RUN apk add --no-cache jq groff less python py-pip && \
   pip install awscli && \


### PR DESCRIPTION
Updates the Atlantis version from V0.4.1 to V0.4.13. Includes a variety of security and bug fixes for alpine linux and Atlantis.